### PR TITLE
Fix: missing c64board/parts.lib due to use of absolute path

### DIFF
--- a/c64mod/c64board/sym-lib-table
+++ b/c64mod/c64board/sym-lib-table
@@ -1,3 +1,3 @@
 (sym_lib_table
-  (lib (name parts)(type Legacy)(uri C:/Users/Reinhard/Documents/GitHub/A-VideoBoard/c64mod/c64board/parts.lib)(options "")(descr ""))
+  (lib (name parts)(type Legacy)(uri ${KIPRJMOD}/parts.lib)(options "")(descr ""))
 )


### PR DESCRIPTION
If you open the files in KiCad it will show up with an error, and the symbols will have to be recovered. Using the project path environment makes the project more portable.